### PR TITLE
Intersight customizations on top of upstream dex v2.45.1

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -91,6 +91,10 @@ func (u *UsernameAttributes) UnmarshalJSON(data []byte) error {
 type UserMatcher struct {
 	UserAttr  string `json:"userAttr"`
 	GroupAttr string `json:"groupAttr"`
+	// Recursive is a legacy flag from the CiscoM31 fork. When explicitly set to
+	// false it disables recursion even if RecursionGroupAttr is non-empty. Absent
+	// (nil) means the upstream behavior applies: recurse when RecursionGroupAttr != "".
+	Recursive *bool `json:"recursive,omitempty"`
 	// Look for parent groups
 	RecursionGroupAttr string `json:"recursionGroupAttr"`
 }
@@ -676,6 +680,19 @@ func (c *ldapConnector) groups(ctx context.Context, user ldap.Entry) ([]string, 
 				c.logger.Error("ldap: groups search returned no groups", "filter", filter)
 			}
 			groups = append(groups, obtained...)
+		}
+
+		// Respect legacy Recursive flag if explicitly set to false
+		if matcher.Recursive != nil && !*matcher.Recursive {
+			for _, group := range groups {
+				name := c.getAttr(*group, c.GroupSearch.NameAttr)
+				if name == "" {
+					return nil, fmt.Errorf("ldap: group entity %q missing required attribute %q",
+						group.DN, c.GroupSearch.NameAttr)
+				}
+				groupNames = append(groupNames, name)
+			}
+			continue
 		}
 
 		// If RecursionGroupAttr is not set, convert direct groups into names and return

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -461,7 +461,8 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 	switch n := len(resp.Entries); n {
 	case 0:
 		c.logger.Error("no results returned for filter", "filter", filter)
-		return ldap.Entry{}, false, nil
+		return ldap.Entry{}, false, fmt.Errorf("ldap: no results returned for filter: %q LDAP Result Code %d %q",
+			filter, ldap.LDAPResultInvalidCredentials, ldap.LDAPResultCodeMap[ldap.LDAPResultInvalidCredentials])
 	case 1:
 		user = *resp.Entries[0]
 		c.logger.Info("username mapped to entry", "username", username, "user_dn", user.DN)
@@ -502,12 +503,13 @@ func (c *ldapConnector) Login(ctx context.Context, s connector.Scopes, username,
 		if err := conn.Bind(user.DN, password); err != nil {
 			// Detect a bad password through the LDAP error code.
 			if ldapErr, ok := err.(*ldap.Error); ok {
-				switch ldapErr.ResultCode {
-				case ldap.LDAPResultInvalidCredentials:
-					c.logger.Error("invalid password for user", "user_dn", user.DN)
-					incorrectPass = true
-					return nil
-				case ldap.LDAPResultConstraintViolation:
+			switch ldapErr.ResultCode {
+			case ldap.LDAPResultInvalidCredentials:
+				c.logger.Error("invalid password for user", "user_dn", user.DN)
+				incorrectPass = true
+				return fmt.Errorf("invalid credentials for user %q LDAP Result Code %d %q",
+					user.DN, ldap.LDAPResultInvalidCredentials, ldap.LDAPResultCodeMap[ldap.LDAPResultInvalidCredentials])
+			case ldap.LDAPResultConstraintViolation:
 					c.logger.Error("constraint violation for user", "user_dn", user.DN, "err", ldapErr.Error())
 					incorrectPass = true
 					return nil

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -75,6 +75,12 @@ func (u *UsernameAttributes) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("username must be a string or list of strings")
 	}
+	s = strings.TrimSpace(s)
+	// Backward compatibility: mailOrSAMAccountName was a special keyword for AD
+	if strings.EqualFold(s, "mailOrSAMAccountName") {
+		*u = UsernameAttributes{"mail", "sAMAccountName"}
+		return nil
+	}
 	if s != "" {
 		*u = UsernameAttributes{s}
 	}
@@ -437,7 +443,18 @@ func (c *ldapConnector) identityFromEntry(user ldap.Entry) (ident connector.Iden
 	if c.UserSearch.EmailSuffix != "" {
 		ident.Email = ident.Username + "@" + c.UserSearch.EmailSuffix
 	} else if ident.Email = c.getAttr(user, c.UserSearch.EmailAttr); ident.Email == "" {
-		missing = append(missing, c.UserSearch.EmailAttr)
+		// Skip email requirement when user has at least one username search attribute.
+		// AD users may lack mail but have sAMAccountName; IdM/OpenLDAP users with uid-only may lack mail in edge cases.
+		hasUsernameAttr := false
+		for _, attr := range c.UserSearch.Username {
+			if c.getAttr(user, attr) != "" {
+				hasUsernameAttr = true
+				break
+			}
+		}
+		if !hasUsernameAttr {
+			missing = append(missing, c.UserSearch.EmailAttr)
+		}
 	}
 	// TODO(ericchiang): Let this value be set from an attribute.
 	ident.EmailVerified = true

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -34,10 +34,12 @@ import (
 //       bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
 //       bindPW: password
 //       userSearch:
-//         # Would translate to the query "(&(objectClass=person)(uid=<username>))"
+//         # Would translate to the query "(&(objectClass=person)(|(uid=<username>)(mail=<username>)))"
 //         baseDN: cn=users,dc=example,dc=com
 //         filter: "(objectClass=person)"
-//         username: uid
+//         username:
+//         - uid
+//         - mail
 //         idAttr: uid
 //         emailAttr: mail
 //         nameAttr: name
@@ -57,6 +59,27 @@ import (
 //           groupAttr: member
 //         nameAttr: name
 //
+
+// UsernameAttributes represents one or more LDAP attributes to match against
+// the username input. It supports unmarshaling from both a single string
+// (e.g. "uid") and a list of strings (e.g. ["uid", "mail"]).
+type UsernameAttributes []string
+
+func (u *UsernameAttributes) UnmarshalJSON(data []byte) error {
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*u = arr
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("username must be a string or list of strings")
+	}
+	if s != "" {
+		*u = UsernameAttributes{s}
+	}
+	return nil
+}
 
 // UserMatcher holds information about user and group matching.
 type UserMatcher struct {
@@ -110,9 +133,10 @@ type Config struct {
 		// Optional filter to apply when searching the directory. For example "(objectClass=person)"
 		Filter string `json:"filter"`
 
-		// Attribute to match against the inputted username. This will be translated and combined
-		// with the other filter as "(<attr>=<username>)".
-		Username string `json:"username"`
+		// Attribute(s) to match against the inputted username. Accepts a single string
+		// or a list of strings. When multiple attributes are specified, an OR filter is
+		// constructed: "(|(<attr1>=<username>)(<attr2>=<username>))".
+		Username UsernameAttributes `json:"username"`
 
 		// Can either be:
 		// * "sub" - search the whole sub tree
@@ -242,13 +266,16 @@ func (c *Config) openConnector(logger *slog.Logger) (*ldapConnector, error) {
 	}{
 		{"host", c.Host},
 		{"userSearch.baseDN", c.UserSearch.BaseDN},
-		{"userSearch.username", c.UserSearch.Username},
 	}
 
 	for _, field := range requiredFields {
 		if field.val == "" {
 			return nil, fmt.Errorf("ldap: missing required field %q", field.name)
 		}
+	}
+
+	if len(c.UserSearch.Username) == 0 {
+		return nil, fmt.Errorf("ldap: missing required field %q", "userSearch.username")
 	}
 
 	var (
@@ -298,7 +325,7 @@ func (c *Config) openConnector(logger *slog.Logger) (*ldapConnector, error) {
 
 	// TODO(nabokihms): remove it after deleting deprecated groupSearch options
 	c.GroupSearch.UserMatchers = userMatchers(c, logger)
-	return &ldapConnector{*c, userSearchScope, groupSearchScope, tlsConfig, logger}, nil
+	return &ldapConnector{*c, userSearchScope, groupSearchScope, tlsConfig, c.UserSearch.Username, logger}, nil
 }
 
 type ldapConnector struct {
@@ -308,6 +335,8 @@ type ldapConnector struct {
 	groupSearchScope int
 
 	tlsConfig *tls.Config
+
+	usernameAttrs []string
 
 	logger *slog.Logger
 }
@@ -421,7 +450,19 @@ func (c *ldapConnector) identityFromEntry(user ldap.Entry) (ident connector.Iden
 }
 
 func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.Entry, found bool, err error) {
-	filter := fmt.Sprintf("(%s=%s)", c.UserSearch.Username, ldap.EscapeFilter(username))
+	var filter string
+	escapedUsername := ldap.EscapeFilter(username)
+
+	attrFilters := make([]string, 0, len(c.usernameAttrs))
+	for _, attr := range c.usernameAttrs {
+		attrFilters = append(attrFilters, fmt.Sprintf("(%s=%s)", attr, escapedUsername))
+	}
+	if len(attrFilters) == 1 {
+		filter = attrFilters[0] // Skip OR wrapper for single attribute
+	} else {
+		filter = fmt.Sprintf("(|%s)", strings.Join(attrFilters, ""))
+	}
+
 	if c.UserSearch.Filter != "" {
 		filter = fmt.Sprintf("(&%s%s)", c.UserSearch.Filter, filter)
 	}
@@ -438,6 +479,8 @@ func (c *ldapConnector) userEntry(conn *ldap.Conn, username string) (user ldap.E
 			// TODO(ericchiang): what if this contains duplicate values?
 		},
 	}
+
+	req.Attributes = append(req.Attributes, c.usernameAttrs...)
 
 	for _, matcher := range c.GroupSearch.UserMatchers {
 		req.Attributes = append(req.Attributes, matcher.UserAttr)

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -45,7 +45,7 @@ func TestQuery(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	tests := []subtest{
 		{
@@ -105,7 +105,7 @@ func TestQueryWithEmailSuffix(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailSuffix = "test.example.com"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	tests := []subtest{
 		{
@@ -141,7 +141,7 @@ func TestUserFilter(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.UserSearch.Filter = "(ou:dn:=Seattle)"
 
 	tests := []subtest{
@@ -184,13 +184,50 @@ func TestUserFilter(t *testing.T) {
 	runTests(t, connectLDAP, c, tests)
 }
 
+func TestUsernameWithMultipleAttributes(t *testing.T) {
+	c := &Config{}
+	c.UserSearch.BaseDN = "ou=TestUsernameWithMultipleAttributes,dc=example,dc=org"
+	c.UserSearch.NameAttr = "cn"
+	c.UserSearch.EmailAttr = "mail"
+	c.UserSearch.IDAttr = "DN"
+	c.UserSearch.Username = UsernameAttributes{"cn", "mail"}
+	c.UserSearch.Filter = "(ou:dn:=Seattle)"
+
+	tests := []subtest{
+		{
+			name:     "cn",
+			username: "jane",
+			password: "foo",
+			want: connector.Identity{
+				UserID:        "cn=jane,ou=People,ou=Seattle,ou=TestUsernameWithMultipleAttributes,dc=example,dc=org",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+			},
+		},
+		{
+			name:     "mail",
+			username: "janedoe@example.com",
+			password: "foo",
+			want: connector.Identity{
+				UserID:        "cn=jane,ou=People,ou=Seattle,ou=TestUsernameWithMultipleAttributes,dc=example,dc=org",
+				Username:      "jane",
+				Email:         "janedoe@example.com",
+				EmailVerified: true,
+			},
+		},
+	}
+
+	runTests(t, connectLDAP, c, tests)
+}
+
 func TestGroupQuery(t *testing.T) {
 	c := &Config{}
 	c.UserSearch.BaseDN = "ou=People,ou=TestGroupQuery,dc=example,dc=org"
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.GroupSearch.BaseDN = "ou=Groups,ou=TestGroupQuery,dc=example,dc=org"
 	c.GroupSearch.UserMatchers = []UserMatcher{
 		{
@@ -238,7 +275,7 @@ func TestGroupsOnUserEntity(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.GroupSearch.BaseDN = "ou=Groups,ou=TestGroupsOnUserEntity,dc=example,dc=org"
 	c.GroupSearch.UserMatchers = []UserMatcher{
 		{
@@ -284,7 +321,7 @@ func TestGroupFilter(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.GroupSearch.BaseDN = "ou=TestGroupFilter,dc=example,dc=org"
 	c.GroupSearch.UserMatchers = []UserMatcher{
 		{
@@ -333,7 +370,7 @@ func TestGroupToUserMatchers(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.GroupSearch.BaseDN = "ou=TestGroupToUserMatchers,dc=example,dc=org"
 	c.GroupSearch.UserMatchers = []UserMatcher{
 		{
@@ -389,7 +426,7 @@ func TestDeprecatedGroupToUserMatcher(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 	c.GroupSearch.BaseDN = "ou=TestDeprecatedGroupToUserMatcher,dc=example,dc=org"
 	c.GroupSearch.UserAttr = "DN"
 	c.GroupSearch.GroupAttr = "member"
@@ -434,7 +471,7 @@ func TestStartTLS(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	tests := []subtest{
 		{
@@ -458,7 +495,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	tests := []subtest{
 		{
@@ -482,7 +519,7 @@ func TestLDAPS(t *testing.T) {
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	tests := []subtest{
 		{
@@ -525,13 +562,43 @@ func TestUsernamePrompt(t *testing.T) {
 	}
 }
 
+func TestUsernameAttributesUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    UsernameAttributes
+		wantErr bool
+	}{
+		{name: "single string", json: `"uid"`, want: UsernameAttributes{"uid"}},
+		{name: "array of strings", json: `["uid","mail"]`, want: UsernameAttributes{"uid", "mail"}},
+		{name: "single element array", json: `["cn"]`, want: UsernameAttributes{"cn"}},
+		{name: "empty string", json: `""`, want: nil},
+		{name: "invalid type", json: `123`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got UsernameAttributes
+			err := got.UnmarshalJSON([]byte(tt.json))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if diff := pretty.Compare(tt.want, got); diff != "" {
+					t.Errorf("unexpected result: %s", diff)
+				}
+			}
+		})
+	}
+}
+
 func TestNestedGroups(t *testing.T) {
 	c := &Config{}
 	c.UserSearch.BaseDN = "ou=People,ou=TestNestedGroups,dc=example,dc=org"
 	c.UserSearch.NameAttr = "cn"
 	c.UserSearch.EmailAttr = "mail"
 	c.UserSearch.IDAttr = "DN"
-	c.UserSearch.Username = "cn"
+	c.UserSearch.Username = UsernameAttributes{"cn"}
 
 	c.GroupSearch.BaseDN = "ou=TestNestedGroups,dc=example,dc=org"
 	c.GroupSearch.UserMatchers = []UserMatcher{

--- a/connector/ldap/ldap_test.go
+++ b/connector/ldap/ldap_test.go
@@ -574,6 +574,8 @@ func TestUsernameAttributesUnmarshal(t *testing.T) {
 		{name: "single element array", json: `["cn"]`, want: UsernameAttributes{"cn"}},
 		{name: "empty string", json: `""`, want: nil},
 		{name: "invalid type", json: `123`, wantErr: true},
+		{name: "mailOrSAMAccountName keyword", json: `"mailOrSAMAccountName"`, want: UsernameAttributes{"mail", "sAMAccountName"}},
+		{name: "mailOrSAMAccountName trimmed", json: `" mailOrSAMAccountName "`, want: UsernameAttributes{"mail", "sAMAccountName"}},
 	}
 
 	for _, tt := range tests {

--- a/connector/ldap/testdata/schema.ldif
+++ b/connector/ldap/testdata/schema.ldif
@@ -505,3 +505,25 @@ objectClass: groupOfNames
 cn: circularGroup2
 member: cn=circularGroup1,ou=Groups,ou=TestNestedGroups,dc=example,dc=org
 member: cn=john,ou=People,ou=TestNestedGroups,dc=example,dc=org
+
+########################################################################
+
+dn: ou=TestUsernameWithMultipleAttributes,dc=example,dc=org
+objectClass: organizationalUnit
+ou: TestUsernameWithMultipleAttributes
+
+dn: ou=Seattle,ou=TestUsernameWithMultipleAttributes,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Seattle
+
+dn: ou=People,ou=Seattle,ou=TestUsernameWithMultipleAttributes,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,ou=Seattle,ou=TestUsernameWithMultipleAttributes,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: janedoe@example.com
+userpassword: foo

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -394,7 +394,7 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 		identity, ok, err := pwConn.Login(r.Context(), scopes, username, password)
 		if err != nil {
 			s.logger.ErrorContext(r.Context(), "failed to login user", "err", err)
-			s.renderError(r, w, http.StatusInternalServerError, ErrMsgLoginError)
+			s.renderError(r, w, http.StatusInternalServerError, "Login Error.", err.Error())
 			return
 		}
 		if !ok {
@@ -1498,10 +1498,28 @@ func (s *Server) writeAccessToken(w http.ResponseWriter, resp *accessTokenRespon
 	w.Write(data)
 }
 
-func (s *Server) renderError(r *http.Request, w http.ResponseWriter, status int, description string) {
-	if err := s.templates.err(r, w, status, description); err != nil {
-		s.logger.ErrorContext(r.Context(), "server template error", "err", err)
+func (s *Server) renderError(r *http.Request, w http.ResponseWriter, status int, description string, errors ...string) {
+	if r == nil {
+		s.logger.Error("cannot render error, request not found")
+		return
 	}
+	resp := struct {
+		ErrorMessage string `json:"errorMsg"`
+		ErrorDetails string `json:"errorDetails"`
+	}{
+		description,
+		strings.Join(errors, ", "),
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "failed to render error", "err", err)
+		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.WriteHeader(status)
+	w.Write(data)
 }
 
 func (s *Server) tokenErrHelper(w http.ResponseWriter, typ string, description string, statusCode int) {


### PR DESCRIPTION
#### Overview

The `integ_2026` branch is based on **upstream dex [v2.45.1](https://github.com/dexidp/dex/releases/tag/v2.45.1)** (commit `11d2eeb5`, released Mar 3 2026). This PR adds the minimal Intersight-specific customizations on top of that clean upstream base.
All previous CiscoM31 custom PRs (#68–#81) have been **dropped** — their functionality is either now upstream or superseded by newer upstream features (PR #4061 for username attributes, PR #4113 for recursive group search). 

#### What this PR does / why we need it
Following are the customizations added specifically for Intersight:

| # | Commit | Type | Description |
|---|--------|------|-------------|
| 1 | `cb128316` | **Custom** | JSON-based error reporting for LDAP login failures — `renderError()` returns `{errorMsg, errorDetails}` JSON instead of HTML, LDAP connector returns error details with LDAP result codes |
| 2 | `f36e1e30` | **Upstream cherry-pick** | [feat(ldap): allow specifying multiple attributes on username input (#4061)](https://github.com/dexidp/dex/pull/4061) — merged upstream Mar 17 2026, cherry-picked since it missed the v2.45.1 release |
| 3 | `1519500c` | **Custom** | Intersight backward compatibility on top of #4061: `mailOrSAMAccountName` keyword expansion to `["mail", "sAMAccountName"]`, and skip email validation when a configured username attribute has a value |
| 4 | `211b4a45` | **Custom** | Legacy `Recursive *bool` backward compatibility — existing customer configs with `recursive: false` continue to disable recursive group search even when `recursionGroupAttr` is set. Uses a pointer to distinguish absent (new configs, upstream behavior) from explicitly false (old configs, skip recursion) |

Commits 3 and 4 are temporary backward compatibility patches. They will be removed after a hurricane startup migration is implemented to rewrite old-format dex configs on upgrade (planned for a future release).

## Files changed
- `connector/ldap/ldap.go` — all 4 commits
- `connector/ldap/ldap_test.go` — commit 3 (2 test cases for mailOrSAMAccountName)
- `server/handlers.go` — commit 1 (JSON error response)

## Previous custom PRs (all dropped)
| PR | Description | Reason |
|----|-------------|--------|
| #68 | mailOrSAMAccountName keyword | Superseded by upstream #4061 + commit 3 compat layer |
| #69, #71 | JSON error reporting | Re-applied as commit 1 |
| #70, #79, #80 | Nested/recursive group search | Superseded by upstream #4113 |
| #72, #81 | Dependency bumps | Superseded by v2.45.1 |
| #75 | Sync test merge | Superseded by fresh sync |

## Testing
- [ ] LDAP login with single username attribute (e.g., `uid`)
- [ ] LDAP login with multiple username attributes (e.g., `["mail", "sAMAccountName"]`)
- [ ] LDAP login with legacy `mailOrSAMAccountName` keyword in config
- [ ] Recursive group search enabled (`recursionGroupAttr: "member"`, no `recursive` field)
- [ ] Recursive group search disabled via legacy config (`recursive: false`, `recursionGroupAttr: "member"`)
- [ ] JSON error response on invalid credentials
- [ ] JSON error response on user not found
#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?


```release-note
"NONE"
```
